### PR TITLE
Port to Skyrim SE 1.7.99 (Address Library format 5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ message("Using toolchain file ${CMAKE_TOOLCHAIN_FILE}.")
 ########################################################################################################################
 project(
     FormListManipulator
-    VERSION 1.7.0.0
+    VERSION 1.7.0.1
     DESCRIPTION "Allows dynamic modification of FormLists."
     LANGUAGES CXX
 )
@@ -57,21 +57,29 @@ source_group(
 ########################################################################################################################
 ## Configure target DLL.
 ########################################################################################################################
-find_package(CommonLibSSE CONFIG REQUIRED)
+
+# Build CommonLibSSE-NG from source (alandtse/CommonLibVR ng branch v6.7.0)
+# for Skyrim 1.7.99 / Address Library format 5 support.
+# The vcpkg-colorglass registry only has v3.7.0 which predates 1.7.99.
+set(ENABLE_SKYRIM_VR OFF)
+set(BUILD_TESTS OFF)
+set(SKSE_SUPPORT_XBYAK ON)
+add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/external/CommonLibNG" CommonLibNG EXCLUDE_FROM_ALL)
+include("${CMAKE_CURRENT_SOURCE_DIR}/external/CommonLibNG/cmake/CommonLibSSE.cmake")
+
 find_package(unordered_dense CONFIG REQUIRED)
-find_package(tsl-ordered-map CONFIG REQUIRED)
 find_path(MERGEMAPPER_INCLUDE_DIRS "MergeMapperPluginAPI.h")
 find_path(CLIB_UTIL_INCLUDE_DIRS "ClibUtil/utils.hpp")
 
 add_commonlibsse_plugin(
-	${PROJECT_NAME} 
-	${PROJECT_AUTHOR}
-	${PROJECT_AUTHOR_EMAIL}
-	${PROJECT_VERSION}
-	SOURCES ${sources} 
+	${PROJECT_NAME}
+	NAME ${PROJECT_FRIENDLY_NAME}
+	AUTHOR ${PROJECT_AUTHOR}
+	EMAIL ${PROJECT_AUTHOR_EMAIL}
+	VERSION ${PROJECT_VERSION}
+	SOURCES ${sources}
 	${MERGEMAPPER_INCLUDE_DIRS}/MergeMapperPluginAPI.cpp
 	)
-add_library("${PROJECT_NAME}::${PROJECT_NAME}" ALIAS "${PROJECT_NAME}")
 
 target_include_directories(${PROJECT_NAME}
         PRIVATE
@@ -85,7 +93,6 @@ target_link_libraries(
 	${PROJECT_NAME}
 	PRIVATE
 		unordered_dense::unordered_dense
-		tsl::ordered_map
 )
 
 target_precompile_headers(${PROJECT_NAME}

--- a/src/Utility/ExternalModules.hpp
+++ b/src/Utility/ExternalModules.hpp
@@ -1,15 +1,11 @@
 #pragma once
 
-#undef MessageBox
-#undef GetModuleHandle
 #include "Types/Types.hpp"
-
-namespace winApi = SKSE::WinAPI;
 
 namespace flm
 {
-	inline winApi::HMODULE tweaks{ nullptr };   /* PowerOfThree Tweaks handle. */
-	inline winApi::HMODULE kid{ nullptr };      /* PowerOfThree KID handle. */
+	inline HMODULE tweaks{ nullptr };   /* PowerOfThree Tweaks handle. */
+	inline HMODULE kid{ nullptr };      /* PowerOfThree KID handle. */
 
 	/**
 	 * \brief Returns the EditorID for a given FromID.
@@ -41,9 +37,9 @@ namespace flm
 	 *
 	 * \return                  - True if module exists.
 	 */
-	inline bool CheckDll(winApi::HMODULE& dll, const wchar_t* dllName)
+	inline bool CheckDll(HMODULE& dll, const wchar_t* dllName)
 	{
-		dll = winApi::GetModuleHandle(dllName);
+		dll = GetModuleHandleW(dllName);
 		return dll != nullptr;
 	}
 
@@ -54,10 +50,10 @@ namespace flm
 	 * \param header            - Header in the displayed message if the dll is not installed.
 	 * \param info              - The contents of the displayed message if the dll is not installed.
 	 */
-	inline void GuardDll(winApi::HMODULE& dll, const wchar_t* dllName, const std::string_view header, const std::string_view info)
+	inline void GuardDll(HMODULE& dll, const wchar_t* dllName, const std::string_view header, const std::string_view info)
 	{
 		if(!CheckDll(dll, dllName))
-			if(const auto id = winApi::MessageBox(nullptr, info.data(), header.data(), 0x00000001); id == 2)
+			if(const auto id = MessageBoxA(nullptr, info.data(), header.data(), 0x00000001); id == 2)
 				std::_Exit(EXIT_FAILURE);
 	}
 

--- a/src/Utility/LogInfo.hpp
+++ b/src/Utility/LogInfo.hpp
@@ -49,21 +49,21 @@ namespace flm::log
 	template<typename... Args>
 	inline void Info(std::string_view format, Args&&... args)
 	{
-		std::string fm = std::vformat(format, std::make_format_args(std::forward<Args>(args)...));
+		std::string fm = fmt::format(fmt::runtime(format), std::forward<Args>(args)...);
 		logger::info("{:{}}{}", "", indent_level * 4, fm);
 	}
 
 	template<typename... Args>
 	inline void Warn(std::string_view format, Args&&... args)
 	{
-		std::string fm = std::vformat(format, std::make_format_args(std::forward<Args>(args)...));
+		std::string fm = fmt::format(fmt::runtime(format), std::forward<Args>(args)...);
 		logger::warn("{:{}}{}", "", indent_level * 4, fm);
 	}
 
 	template<typename... Args>
 	inline void Error(std::string_view format, Args&&... args)
 	{
-		std::string fm = std::vformat(format, std::make_format_args(std::forward<Args>(args)...));
+		std::string fm = fmt::format(fmt::runtime(format), std::forward<Args>(args)...);
 		logger::error("{:{}}{}", "", indent_level * 4, fm);
 	}
 

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,4 +1,9 @@
 {
+    "default-registry": {
+        "kind": "git",
+        "repository": "https://github.com/microsoft/vcpkg",
+        "baseline": "114d9fe62faf35856b45cf55cb93b57028a45d63"
+    },
     "registries": [
         {
             "kind": "git",
@@ -6,8 +11,6 @@
             "baseline": "6309841a1ce770409708a67a9ba5c26c537d2937",
             "packages": [
                 "bethesda-skyrim-scripts",
-                "commonlibsse-ng",
-                "commonlibsse-ng-prebuilt",
                 "gluino",
                 "script-extender-common",
                 "skse"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,19 +1,22 @@
 {
     "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
     "name": "formlistmanipulator",
-    "version": "1.7.0",
+    "version": "1.7.0.1",
     "description": "Allows dynamic modification of FormLists.",
     "homepage": "https://www.nexusmods.com/skyrimspecialedition/mods/74037",
     "dependencies": [
-        "boost-stl-interfaces",
         "boost-regex",
-        "boost-algorithm",
         "clib-util",
-        "commonlibsse-ng",
         "mergemapper",
-        "rsm-binary-io",
-        "tsl-ordered-map",
         "unordered-dense",
-        "simpleini"
+        "simpleini",
+        "directxmath",
+        "directxtk",
+        "fmt",
+        "nlohmann-json",
+        "rapidcsv",
+        "spdlog",
+        "toml11",
+        "xbyak"
     ]
 }


### PR DESCRIPTION
## Skyrim SE 1.7.99 Port

This PR updates FormList Manipulator to work with Skyrim SE 1.7.99 (released August 20, 2026), which introduced Address Library format 5 and broke many SKSE plugins.

### What changed

Build CommonLibSSE-NG from source ([alandtse/CommonLibVR](https://github.com/alandtse/CommonLibVR) ng branch v6.7.0) instead of using the vcpkg-colorglass registry package (v3.7.0, which predates 1.7.99).

**Source code changes** (2 files, ~20 lines):
- \ExternalModules.hpp\: \SKSE::WinAPI\ namespace removed in CommonLib 6.7.0 → direct Win32 API
- \LogInfo.hpp\: \std::make_format_args\ broken in MSVC 14.44 C++23 → \mt::format\

**Build system changes** (3 files):
- \CMakeLists.txt\: Build CommonLibNG from source via \dd_subdirectory\
- \cpkg.json\: Replace \commonlibsse-ng\ with CommonLib's transitive deps
- \cpkg-configuration.json\: Add default vcpkg registry

### Testing

- Built successfully with Visual Studio 2022 (MSVC 14.44)
- Verified DLL loads in Skyrim SE 1.7.99
- No logic changes, pure compatibility update

### Credits

Original mod by MaskedRPGFan (MIT License)
Port using [CommonLibVR](https://github.com/alandtse/CommonLibVR) ng branch by alandtse